### PR TITLE
updated command list to verge v4.0.0

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,57 +1,96 @@
 
 var commands = module.exports.commands = [
-    'addMultiSigAddress'
-  , 'backupWallet'
-  , 'createRawTransaction'
-  , 'decodeRawTransaction'
-  , 'dumpPrivKey'
-  , 'encryptWallet'
-  , 'getAccount'
-  , 'getAccountAddress'
-  , 'getAddressesByAccount'
-  , 'getBalance'
-  , 'getBlock'
-  , 'getBlockCount'
-  , 'getBlockHash'
-  , 'getConnectionCount'
-  , 'getDifficulty'
-  , 'getGenerate'
-  , 'getHashesPerSec'
-  , 'getInfo'
-  , 'getMemoryPool'
-  , 'getMiningInfo'
-  , 'getNewAddress'
-  , 'getRawTransaction'
-  , 'getReceivedByAccount'
-  , 'getReceivedByAddress'
-  , 'getTransaction'
-  , 'getWork'
-  , 'help'
-  , 'importPrivKey'
-  , 'importAddress'
-  , 'keyPoolRefill'
-  , 'listAccounts'
-  , 'listReceivedByAccount'
-  , 'listReceivedByAddress'
-  , 'listSinceBlock'
-  , 'listTransactions'
-  , 'listUnspent'
-  , 'move'
-  , 'sendFrom'
-  , 'sendMany'
-  , 'sendRawTransaction'
-  , 'sendToAddress'
-  , 'setAccount'
-  , 'setGenerate'
-  , 'setTxFee'
-  , 'signMessage'
-  , 'signRawTransaction'
-  , 'stop'
-  , 'validateAddress'
-  , 'verifyMessage'
-  , 'walletLock'
-  , 'walletPassphrase'
-  , 'walletPassphraseChange'
+    'addMultiSigAddress',
+    'backupWallet',
+    'checkWallet',
+    'createRawTransaction',
+    'decodeRawTransaction',
+    'dumpPrivKey',
+    'encryptWallet',
+    'getAccount',
+    'getAccountAddress',
+    'getAddressesByAccount',
+    'getBalance',
+    'getBlock',
+    'getBlockByNumber',
+    'getBlockCount',
+    'getBlockCount',
+    'getBlockHash',
+    'getBlockTemplate',
+    'getCheckpoint',
+    'getConnectionCount',
+    'getDifficulty',
+    'getGenerate',
+    'getHashesPerSec',
+    'getHashesPerSec',
+    'getInfo',
+    'getMemoryPool',
+    'getMemoryPool',
+    'getMiningInfo',
+    'getNewAddress',
+    'getNewPubKey',
+    'getNewStealthAddress',
+    'getPeerInfo',
+    'getRawBlockByNumber',
+    'getRawMempool',
+    'getRawTransaction',
+    'getReceivedByAccount',
+    'getReceivedByAddress',
+    'getTransaction',
+    'getWork',
+    'getWorkex',
+    'help',
+    'importAddress',
+    'importPrivKey',
+    'importStealthAddress',
+    'keyPoolRefill',
+    'listAccounts',
+    'listAddressGroupings',
+    'listReceivedByAccount',
+    'listReceivedByAddress',
+    'listSinceBlock',
+    'listStealthAddresses',
+    'listTransactions',
+    'listUnspent',
+    'makeKeypair',
+    'move',
+    'repairWallet',
+    'resendTx',
+    'reserveBalance',
+    'scanForAllTxns',
+    'scanForStealthTxns',
+    'sendAlert',
+    'sendFrom',
+    'sendMany',
+    'sendRawTransaction',
+    'sendToAddress',
+    'sendToStealthAddress',
+    'setAccount',
+    'setGenerate',
+    'setTxFee',
+    'signMessage',
+    'signRawTransaction',
+    'smsgAddKey',
+    'smsgBuckets',
+    'smsgDisable',
+    'smsgEnable',
+    'smsgGetPubKey',
+    'smsgInbox',
+    'smsgLocalkeys',
+    'smsgOptions',
+    'smsgOutbox',
+    'smsgScanBuckets',
+    'smsgScanChain',
+    'smsgSend',
+    'smsgSendanon',
+    'stop',
+    'submitBlock',
+    'validateAddress',
+    'validatePubKey',
+    'verifyMessage',
+    'walletLock',
+    'walletPassphrase',
+    'walletPassphraseChange'
 ]
 
 module.exports.isCommand = function(command) {


### PR DESCRIPTION
I've closed #6 because it would have overwritten some merges which i had not synec.

The command list was extracted from verge 4.0.0.

@justinvforvendetta i'm thinking about re-writing this whole repository with the following features

- ES5/ES6 ( class syntax etc ... )
- Well documentated JSDocs and markdown files
- Unit testing

Optional

- an http server allowing to receive and process realtime transactions using the `walletnotify` and `blocknotify` option in the config file

the transaction could be handled as follow

`
vergeClient.on('transaction', (tx) => {
     //do something with the tx
})
`

We should leave this repository as it is and create a new one because it would only support node >= 7.x


what do you think about it?

  